### PR TITLE
fix: add nvim-lsp-config

### DIFF
--- a/nvim/lazy-lock.json
+++ b/nvim/lazy-lock.json
@@ -29,6 +29,7 @@
   "nvim-cmp": { "branch": "main", "commit": "a1d504892f2bc56c2e79b65c6faded2fd21f3eca" },
   "nvim-dap": { "branch": "master", "commit": "531771530d4f82ad2d21e436e3cc052d68d7aebb" },
   "nvim-dap-ui": { "branch": "master", "commit": "1a66cabaa4a4da0be107d5eda6d57242f0fe7e49" },
+  "nvim-lspconfig": { "branch": "master", "commit": "a683e0ddf0cf64c6cd689e18ffb480ade3c162b7" },
   "nvim-navic": { "branch": "master", "commit": "f5eba192f39b453675d115351808bd51276d9de5" },
   "nvim-nio": { "branch": "master", "commit": "21f5324bfac14e22ba26553caf69ec76ae8a7662" },
   "nvim-notify": { "branch": "master", "commit": "8701bece920b38ea289b457f902e2ad184131a5d" },

--- a/nvim/lua/plugins.lua
+++ b/nvim/lua/plugins.lua
@@ -3,6 +3,7 @@
 -- for LSP
 local lsp_plugins = {
   'SmiteshP/nvim-navic',
+  'neovim/nvim-lspconfig',
 }
 
 -- for cmp


### PR DESCRIPTION
As I suspected, nvim-lsp-config was necessary even without explicitly calling `require(nvim-lsp-config)`...